### PR TITLE
upgrade terminal_size to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75"  # Could perhaps be even older, but this is 2 years at tim
 
 [dependencies]
 atty = "0.2"
-terminal_size = "0.2"
+terminal_size = "0.4"
 yansi = "0.5"
 
 [dev-dependencies]

--- a/src/width.rs
+++ b/src/width.rs
@@ -5,7 +5,9 @@
 use terminal_size::Width;
 #[cfg(unix)]
 pub(crate) fn stdout_width() -> Option<usize> {
-    terminal_size::terminal_size_using_fd(1).map(|(Width(w), _)| w as usize)
+    unsafe {
+        terminal_size::terminal_size_using_fd(1).map(|(Width(w), _)| w as usize)
+    }
 }
 
 #[cfg(windows)]
@@ -16,7 +18,9 @@ pub(crate) fn stdout_width() -> Option<usize> {
 
 #[cfg(unix)]
 pub(crate) fn stderr_width() -> Option<usize> {
-    terminal_size::terminal_size_using_fd(2).map(|(Width(w), _)| w as usize)
+    unsafe {
+        terminal_size::terminal_size_using_fd(2).map(|(Width(w), _)| w as usize)
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
from:

https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/nutmeg/debian/patches/support-newer-terminal-size.diff?ref_type=heads